### PR TITLE
Cleanup stale .next backup + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ next-env.d.ts
 test-results/
 .next-stale-backup/
 playwright-report/
+.next-stale-*


### PR DESCRIPTION
## Summary
- Removed `.next-stale-r27` directory
- Added `.next-stale-*` to .gitignore to prevent future stale backups from being tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)